### PR TITLE
Add intersphinx mappings to autolink to corresponding docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,6 +57,8 @@ extensions = [
 # Mappings for sphinx.ext.intersphinx. Projects have to have Sphinx-generated doc! (.inv file)
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
+    'pandas': ('https://pandas.pydata.org/docs/', None),
+    'pysm3': ('https://pysm3.readthedocs.io/en/stable/', None),
 }
 
 


### PR DESCRIPTION
There are a few cross-references to these docs, adding them as intersphinx mappings allows Sphinx to automatically add links to them.

For example here is an automatically generated link to pandas docs:
![2025-01-16-133209_708x546_scrot](https://github.com/user-attachments/assets/79c79428-da11-40fd-b1df-4929ff94d092)
